### PR TITLE
Remove Mandatory Default From Factory

### DIFF
--- a/avl/_core/factory.py
+++ b/avl/_core/factory.py
@@ -11,6 +11,7 @@ class Factory:
     _by_type = {}
     _by_instance = {}
     _variables = {}
+    _sentinal = object()
 
     @staticmethod
     def specificity(pattern : str) -> int:
@@ -135,15 +136,15 @@ class Factory:
             Factory._variables[path] = value
 
     @staticmethod
-    def get_variable(path: str, original: Any) -> Any:
+    def get_variable(path: str, default: Any=_sentinal) -> Any:
         """
-        Get the value of a variable by its path if it exists, otherwise return the original value.
+        Get the value of a variable by its path if it exists, otherwise return the default value.
 
-        :param original: The original value to return if no match is found.
-        :type original: Any
+        :param defautl: The default value to return if no match is found.
+        :type default: Any
         :param path: The path to the variable.
         :type path: str
-        :return: The value of the variable or the original value.
+        :return: The value of the variable or the default value.
         :rtype: Any
         """
         matches = [value for value in Factory._variables if fnmatch.fnmatch(path, value)]
@@ -151,8 +152,11 @@ class Factory:
         if matches:
             closest_match = max(matches, key=Factory.specificity)
             return Factory._variables[closest_match]
+        elif default is not Factory._sentinal:
+            return default
         else:
-            return original
+            raise KeyError(f"No variable in the factory matches Path argument ({path}), \
+                and no default value is provided.")
 
 
 __all__ = ["Factory"]

--- a/doc/source/factory/factory.rst
+++ b/doc/source/factory/factory.rst
@@ -40,13 +40,15 @@ Variables
 Similar to the UVM config_db / resource_db variables can be set and retrieved from the factory. \
 No copying is done automatically, classes are passed by reference and literals by value. \
 
-The factory supports the sharing of any type via the :doc:`Factory.set_variable </modules/avl._core.factory>` \
-and :doc:`Factory.get_variable </modules/avl._core.factory>` methods as shown below. \
-For instance, :doc:`avl.Var </modules/avl._core.var>` objects can be easily shared, as can cocotb hdl handles. \
+The :doc:`Factory.set_variable </modules/avl._core.factory>` method adds a variable to the \
+factory at a path. Wildcards are allowed in the path. When the :doc:`Factory.get_variable </modules/avl._core.factory>` \
+method is called, it will attempt to match the provided path to the existing paths in the factory. \
+If a match is found, it will return the associated value. If multiple matches are found, the Factory will use the \
+:doc:`Factory.specificity </modules/avl._core.factory>` method on the matching paths to determine which path \
+is the most specific, then it will return the value associated with that path. \  
+Otherwise, it will return a default value. If no default value is provided, it will raise a `KeyError <https://docs.python.org/3/library/exceptions.html>`_.
 
-When getting a variable, a default value may be used if provided. 
-
-
-The same wildcards as for the override by instance are supported :any:`Factory.specificity`. \
+The Factory can be useful for sharing :doc:`avl.Var </modules/avl._core.var>` objects, cocotb hdl handles, 
+and configurations for components.
 
 .. literalinclude:: ../../../examples/factory/variables/cocotb/example.py

--- a/doc/source/factory/factory.rst
+++ b/doc/source/factory/factory.rst
@@ -40,7 +40,12 @@ Variables
 Similar to the UVM config_db / resource_db variables can be set and retrieved from the factory. \
 No copying is done automatically, classes are passed by reference and literals by value. \
 
-This means :doc:`avl.Var </modules/avl._core.var>` objects can be easily shared, as can cocotb hdl handles.
+The factory supports the sharing of any type via the :doc:`Factory.set_variable </modules/avl._core.factory>` \
+and :doc:`Factory.get_variable </modules/avl._core.factory>` methods as shown below. \
+For instance, :doc:`avl.Var </modules/avl._core.var>` objects can be easily shared, as can cocotb hdl handles. \
+
+When getting a variable, a default value may be used if provided. 
+
 
 The same wildcards as for the override by instance are supported :any:`Factory.specificity`. \
 

--- a/examples/factory/variables/cocotb/example.py
+++ b/examples/factory/variables/cocotb/example.py
@@ -12,26 +12,19 @@ class example_env(avl.Env):
     def __init__(self, name, parent):
         super().__init__(name, parent)
 
-        self.a = avl.Factory.get_variable(f"{self.get_full_name()}.a")
+        # Get variable env.a in factory (set in the test method)
+        self.a = avl.Factory.get_variable(f"{self.get_full_name()}.a") 
 
         if self.a != 100:
             self.error(f"Expected a to be 100, got {self.a}")
 
-
-        self.b = avl.Factory.get_variable(f"{self.get_full_name()}.b", 200)
+        # Get variable env.b from the factory. Because it was never set, use the default
+        # value 200 instead.
+        self.b = avl.Factory.get_variable(f"{self.get_full_name()}.b", default=200)
 
         if self.b != 200:
             self.error(f"Expected b to be 200, got {self.b}")
-        
 
-        try:
-            avl.Factory.get_variable(f"{self.get_full_name()}.c")
-            missing_variable_errors = False
-        except KeyError:
-            missing_variable_errors = True
-
-        if missing_variable_errors is False:
-            self.error(f"Excepted missing varaible to error. It did not.")
 
 
 @cocotb.test

--- a/examples/factory/variables/cocotb/example.py
+++ b/examples/factory/variables/cocotb/example.py
@@ -12,10 +12,26 @@ class example_env(avl.Env):
     def __init__(self, name, parent):
         super().__init__(name, parent)
 
-        self.a = avl.Factory.get_variable(f"{self.get_full_name()}.a", 0)
+        self.a = avl.Factory.get_variable(f"{self.get_full_name()}.a")
 
         if self.a != 100:
             self.error(f"Expected a to be 100, got {self.a}")
+
+
+        self.b = avl.Factory.get_variable(f"{self.get_full_name()}.b", 200)
+
+        if self.b != 200:
+            self.error(f"Expected b to be 200, got {self.b}")
+        
+
+        try:
+            avl.Factory.get_variable(f"{self.get_full_name()}.c")
+            missing_variable_errors = False
+        except KeyError:
+            missing_variable_errors = True
+
+        if missing_variable_errors is False:
+            self.error(f"Excepted missing varaible to error. It did not.")
 
 
 @cocotb.test


### PR DESCRIPTION
Currently, to get a variable from the factory with the `get_variable` method. The user must provide a `original` aka default value to be returned if the provided path does not match in any in the factory. Sometimes, there is no sensible default value fo the user to use. This leads to a scenario where the user provides a sentinal value and checks if the `get_variable` returned the sentinal. For example:
```py
my_var = Factory.get_variable("path.to.my.required.variable", None)
assert my_var is not None
```
Instead it would be less verbose if the user could simply write:
```py
my_var = Factory.get_variable("path.to.my.required.variable")
```
This pull request implements this behavior. The Factory will now allow the user to provide no default. If a factory lookup fails, a `KeyError` is raised.