### PR TITLE
Make logger methods in Object instances visable to static type checkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Added
+
+### Fixed
+ - [#32](https://github.com/projectapheleia/avl/issues/32) Object(): use assignment instead of setattr to set logger methods
+
 ## [v0.2.2] - 2025-09-09
 
 ### Added

--- a/avl/_core/object.py
+++ b/avl/_core/object.py
@@ -216,8 +216,13 @@ class Object:
         self._min_values_ = {}
 
         # Logger - Make all logger functions available in class to simplify code
-        for i in ["debug", "info", "warn", "warning", "error", "critical", "fatal"]:
-            setattr(self, i, getattr(Log, i))
+        self.debug = Log.debug
+        self.info = Log.info
+        self.warn = Log.warn
+        self.warning = Log.warning
+        self.error = Log.error
+        self.critical = Log.critical
+        self.fatal = Log.fatal
 
         # Table format for string representation
         self._table_fmt_ = "grid"


### PR DESCRIPTION
Because the logger methods are bound to `avl.Object` instances in the `__init__` method using the `setattr` method. They can be hidden from static type checkers. 
```python
class MyObject(avl.Object):
    def my_method(self):
        self.info("print something") # Warning: Cannot access attribute "info" for class "MyObject"
```
This pull request assigns the logger methods to object instances without using `setattr`:
```python
self.info = Log.info
```