### PR TITLE
added kwargs check in Object class

### DIFF
--- a/avl/_core/object.py
+++ b/avl/_core/object.py
@@ -197,8 +197,17 @@ class Object:
         if not args and not kwargs:
             return super().__new__(cls)
 
-        name = args[0]
-        parent = args[1]
+        if args:
+            name = args[0]
+            parent = args[1] if len(args) > 1 else None
+        else:
+            # Handle keyword arguments
+            name = kwargs.get('name')
+            parent = kwargs.get('parent')
+        
+        # Validate we have required parameters
+        if name is None:
+            raise TypeError(f"{cls.__name__} requires 'name' parameter")
         path = name
 
         # No factory for hidden Objects


### PR DESCRIPTION
__new__ function in Object class can work with either positional or keyword arguments, but only takes input from positional ones. if you try to create a new instance of anything that relies on avl.Object, only using keyword arguments, it fails.

This PR fixes that