### PR TITLE
Logic: added the option to format values

### DIFF
--- a/avl/_core/var.py
+++ b/avl/_core/var.py
@@ -265,6 +265,10 @@ class Var:
     def __repr__(self): return self._fmt_(self.value)
     def __str__(self): return self._fmt_(self.value)
 
+    def __format__(self, format_spec):
+        # Delegate formatting to the underlying int value
+        return format(self.value, format_spec)
+
     # Hashing
     def __hash__(self): return hash(self.value)
 


### PR DESCRIPTION
Added a formatting function, so that
`addr = avl.Uint64(0xFFFF_FFFF) 
print(f"full addr: 0x{addr:x}")`
doesn't throw an error :)