### PR TITLE
Fix Coverbin stddev assertion for bins with <=1 sample

### DIFF
--- a/avl/_core/coverbin.py
+++ b/avl/_core/coverbin.py
@@ -147,9 +147,14 @@ class Coverbin(Component):
         :rtype: float
         """
         if self.stats:
+            # Fewer than 2 samples has no defined sample variance/stddev.
+            if self._count_ <= 1:
+                return None
+
             variance = self.get_variance()
-            assert variance is not None
-            return sqrt(variance) if self._count_ > 1 else None
+            if variance is None:
+                return None
+            return sqrt(variance)
         else:
             return None
 


### PR DESCRIPTION
If self._count is smaller or equal to 1 the get_variance function returns None and the assertion fails. This blocks getting the coverage report.