### PR TITLE
core: skip constraints with no solver variables

### DIFF
--- a/avl/_core/object.py
+++ b/avl/_core/object.py
@@ -634,10 +634,16 @@ class Object:
 
             solver = Optimize()
 
+            def is_solver_var(a : Any) -> bool:
+                return isinstance(a, Var) and a._auto_random_ and a._idx_ in var_ids
+
             # Apply class wide constraints
             for truth_value, add_fn in [(True, solver.add),
                                         (False, lambda expr: solver.add_soft(expr, weight=100))]:
                 for fn, args in self._constraints_[truth_value].values():
+                    # Skip: no solver var → constraint may collapse to Python False → UNSAT.
+                    if not any(is_solver_var(a) for a in args):
+                        continue
                     _args = [resolve_arg(a) for a in args]
                     add_fn(fn(*_args))
 


### PR DESCRIPTION
## Summary

`Object.randomize()` silently UNSATs when a hard constraint references only Vars that have been frozen (`_auto_random_ = False`) and the frozen values violate the constraint.

`resolve_arg` returns the frozen Var's plain Python value, so the user lambda evaluates entirely in Python and returns a Python `bool`.
If that bool is `False`, `solver.add(False)` makes the optimizer permanently UNSAT — before any real constraint is built.

Affects any caller that freezes a subset of Vars before `randomize()`, including `avl_apb.SequenceItem.randomize_request` / `randomize_completion`, where it manifests as silent failures in `CplMemoryDriver`'s `pslverr=1` injection path.

## Fix

In `new_solver()`, skip any constraint whose arguments contain no solver variable.
Such a constraint's truth is determined by the current frozen state and cannot be affected by the solver; including it serves no purpose and is what enables the silent-UNSAT failure mode.

## Reproducer

```python
import avl

class Item(avl.Object):
    def __init__(self):
        super().__init__("item", None)
        self.a = avl.Logic(self, "a", 8, 0)
        self.b = avl.Logic(self, "b", 8, 0)
        self.add_constraint("c_a_nonzero", lambda x: x != 0, self.a)

item = Item()
item.a._auto_random_ = False     # freeze a at value 0
item.randomize()                 # before: raises; after: passes, b gets a random value
```