### PR TITLE
Fix #95: Log._flush_log() writes the final buffer twice

### DIFF
--- a/avl/_core/log.py
+++ b/avl/_core/log.py
@@ -101,14 +101,6 @@ class Log:
 
         if len(Log._logdata["Time"]) >= Log._flush_level:
             Log._flush_log()
-            Log._logdata = {
-                "Time": [],
-                "Level": [],
-                "Group": [],
-                "Message": [],
-                "Filename": [],
-                "LineNo": [],
-            }
 
     @staticmethod
     def _override_cocotb_logging() -> None:
@@ -172,7 +164,7 @@ class Log:
         The log data is converted to a pandas DataFrame before writing.
         """
 
-        if Log._logfile is not None:
+        if Log._logfile is not None and len(Log._logdata["Time"]) > 0:
             fileext = os.path.splitext(Log._logfile)[1]
             d = pd.DataFrame(Log._logdata)
             mode = "w" if Log._first else "a"
@@ -205,6 +197,7 @@ class Log:
                 raise ValueError(f"Unsupported file extension {fileext}")
 
             Log._first = False
+            Log._logdata = {"Time": [], "Level": [], "Group": [], "Message": [], "Filename": [], "LineNo": []}
 
     @staticmethod
     def set_logfile(logfile: str) -> None:


### PR DESCRIPTION
Fixes #95.

`Log._flush_log()` appended `Log._logdata` to the log file but never
cleared it - only `_avl_callback()` cleared it, and only when the
flush-level threshold was reached. `_override_cocotb_logging()` installs
two shutdown paths that both call `_flush_log()` (the
`RegressionManager._log_test_summary` patch, and an `atexit` fallback for
simulators that skip it), so any records still in the buffer at
end-of-test got written out a second time.

`_flush_log()` now clears `Log._logdata` after writing and is a no-op
when the buffer is empty, so both shutdown paths are safe regardless of
how many of them fire, and the buffer-reset lives in one place instead of
only in `_avl_callback()`.

