### PR TITLE
Fix repeated table headers on multi-flush for txt/md/rst logs

### DIFF
--- a/avl/_core/log.py
+++ b/avl/_core/log.py
@@ -190,16 +190,27 @@ class Log:
                     )
             elif fileext == ".txt":
                 with open(Log._logfile, mode) as f:
+                    if not Log._first:
+                        f.write("\n\n")
                     f.write(
                         tabulate.tabulate(d.values.tolist(), headers=d.columns, tablefmt="grid")
                     )
             elif fileext == ".md":
+                # Only the first flush renders the header/separator row - later
+                # flushes append bare rows so the file stays one valid table
+                # instead of several concatenated ones.
                 with open(Log._logfile, mode) as f:
-                    markdown_view = d.to_markdown(index=False)
-                    assert markdown_view is not None
-                    f.write(markdown_view)
+                    if Log._first:
+                        markdown_view = d.to_markdown(index=False)
+                        assert markdown_view is not None
+                        f.write(markdown_view)
+                    else:
+                        rows = "\n".join("| " + " | ".join(str(v) for v in row) + " |" for row in d.values.tolist())
+                        f.write("\n" + rows)
             elif fileext == ".rst":
                 with open(Log._logfile, mode) as f:
+                    if not Log._first:
+                        f.write("\n\n")
                     f.write(tabulate.tabulate(d, headers="keys", tablefmt="rst", showindex=False))
             else:
                 raise ValueError(f"Unsupported file extension {fileext}")


### PR DESCRIPTION

- `Log._flush_log()` re-rendered the whole in-memory chunk on every flush for the `.txt`/`.md`/`.rst` formats and appended it in mode `"a"`, so a run that flushed more than once ended up with several table headers concatenated with no separating blank line — cosmetic for txt/rst, but an invalid single table for markdown.
- `.txt`/`.rst` now insert a blank line between flushed chunks, keeping them as multiple cleanly-separated tables.
- `.md` now renders the header/separator row only on the first flush and appends bare rows afterwards, so the file stays one valid table across any number of flushes — mirroring how the `.csv` branch keeps a single header and `.json` writes one object per line.

Fixes #97
